### PR TITLE
fix possible varDiff issues and adjust default `min_share_diff`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Shares-based work allocation with miner-like periodic stat output:
  lemois         |       0.13GH/s |          3/0/0 |            0 |       6m48s
 -------------------------------------------------------------------------------
                 |       0.13GH/s |          3/0/0 |            0 |       7m20s
-========================================================= kls_bridge_v2.0.0 ===
+========================================================= kls_bridge_v2.1.0 ===
 ```
 
 ## Variable difficulty engine (vardiff)

--- a/cmd/karlsenbridge/config.yaml
+++ b/cmd/karlsenbridge/config.yaml
@@ -1,40 +1,42 @@
 # stratum_listen_port: the port that will be listening for incoming stratum
 # traffic
-# Note `:PORT` format is needed if not specifiying a specific ip range
+# Note `:PORT` format is needed if not specifying a specific IP range
 stratum_port: :5555
 
-# karlsend_address: address/port of the rpc server for karlsend, typically 42110
-# For a list of public nodes, run `nslookup mainnet-dnsseed.daglabs-dev.com`
-# uncomment for to use a public node
+# karlsend_address: address/port of the RPC server for karlsend, typically 42110
+# For a list of public nodes, run `nslookup mainnet-dnsseed-1.karlsencoin.com`
+# Uncomment to use a public node
 # karlsend_address: 46.17.104.200:42110
 karlsend_address: localhost:42110
 #karlsend_address: localhost:42210
 
 # min_share_diff: only accept shares of the specified difficulty (or higher)
-# from the miner(s).  Higher values will reduce the number of shares submitted,
+# from the miner(s). Higher values will reduce the number of shares submitted,
 # thereby reducing network traffic and server load, while lower values will
 # increase the number of shares submitted, thereby reducing the amount of time
 # needed for accurate hashrate measurements.
 #
 # If var_diff is enabled, min_share_diff will be the starting difficulty.
 #
-# Default value is chosen to accomodate current top of the line GPUs. If you
+# Default value is chosen to accommodate current top-of-the-line GPUs. If you
 # don't want to change the default to match your device(s), the vardiff engine
 # will adjust to an appropriate diff for lower hashrate devices within a few
 # minutes.
-min_share_diff: 64
+#
+# If set to 0, the minimum difficulty will default to 0.1
+min_share_diff: 4
 
 # var_diff: if true, enables the auto-adjusting variable share diff mechanism.
 # Starts with the value defined by the 'min_share_diff' setting, then checks
 # every 10s whether each client is maintaining a 20 shares/minute submission
 # rate, and sends an updated min diff per client if necessary. Max tolerance
-# is +/- 5% after 4hrs.
+# is +/- 5% after 4 hours.
 var_diff: true
 
 # shares_per_min: number of shares per minute the vardiff engine should target.
 # Default value is chosen to allow for 95% confidence in measurement accuracy,
 # which affects fidelity of difficulty update decisions, as well as hashrate
-# stability (measured 1hr avg hashrate should be within +/- 10% of actual, with
+# stability (measured 1-hour average hashrate should be within +/- 10% of actual, with
 # the noted confidence.)  Higher values will result in better vardiff engine
 # performance and increased hashrate stability.  Lower values will cause
 # vardiff to behave more erratically, while measured hashrate will display
@@ -44,8 +46,8 @@ var_diff: true
 # 20 => 99%, 15 => 95%, 12 => 90%
 shares_per_min: 15
 
-# var_diff_stats: if true, print vardiff engine stats to the log every 10s
-var_diff_stats: false
+# var_diff_stats: if true, print vardiff engine stats to the log every 10 seconds
+var_diff_stats: true
 
 # block_wait_time: time to wait since last new block message from karlsend before
 # manually requesting a new block. Examples are '500ms', '3s', '1m', etc.
@@ -55,7 +57,7 @@ block_wait_time: 3s
 # With no extranonce (0), all clients will search through the same nonce-space,
 # therefore performing duplicate work unless the miner(s) implement client
 # side nonce randomizing.  More bytes allow for more clients with unique
-# nonce-spaces (i.e. no overlapping work), but reduces the per client
+# nonce-spaces (i.e. no overlapping work), but reduces the per-client
 # overall nonce-space (though with 1s block times, this shouldn't really
 # be a concern).
 # 1 byte = 256 clients, 2 bytes = 65536, 3 bytes = 16777216.
@@ -68,9 +70,9 @@ print_stats: true
 # log_to_file: if true logs will be written to a file local to the executable
 log_to_file: true
 
-# prom_port: if specified, prometheus will serve stats on the port provided
-# see readme for summary on how to get prom up and running using docker
-# you can get the raw metrics (along with default golang metrics) using
+# prom_port: if specified, Prometheus will serve stats on the port provided
+# See readme for a summary on how to get Prometheus up and running using Docker
+# You can get the raw metrics (along with default GoLang metrics) using
 # `curl http://localhost:{prom_port}/metrics`
-# Note `:PORT` format is needed if not specifiying a specific ip range
+# Note `:PORT` format is needed if not specifying a specific IP range
 prom_port: :2114

--- a/misc/hive-templates/kls_srb_local_adapter.json
+++ b/misc/hive-templates/kls_srb_local_adapter.json
@@ -26,7 +26,7 @@
                 "url": "YOUR_KARLSEND_NODE_IP_HERE:42110",
                 "miner": "kls_bridge",
                 "template": "doesnt.matter",
-                "install_url": "https://github.com/karlsen-network/karlsen-stratum-bridge/releases/download/v2.0.0/kls_bridge-2.0.0_hive.tar.gz"
+                "install_url": "https://github.com/karlsen-network/karlsen-stratum-bridge/releases/download/v2.1.0/kls_bridge-v2.1.0_hive.tar.gz"
             },
             "pool_geo": []
         }

--- a/src/karlsenstratum/client_handler.go
+++ b/src/karlsenstratum/client_handler.go
@@ -133,11 +133,6 @@ func (c *clientListener) NewBlockAvailable(kapi *KarlsenApi) {
 			}
 
 			varDiff := c.shareHandler.getClientVardiff(client)
-			if varDiff < c.minShareDiff {
-				stats := c.shareHandler.getCreateStats(client)
-				updateVarDiff(stats, c.minShareDiff)
-				varDiff = c.minShareDiff
-			}
 			if varDiff != state.stratumDiff.diffValue {
 				// send updated vardiff
 				client.Logger.Info(fmt.Sprintf("changing diff from %f to %f", state.stratumDiff.diffValue, varDiff))

--- a/src/karlsenstratum/stratum_server.go
+++ b/src/karlsenstratum/stratum_server.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const version = "v2.0.0"
+const version = "v2.1.0"
 const minBlockWaitTime = 3 * time.Second
 
 type BridgeConfig struct {

--- a/src/karlsenstratum/stratum_server.go
+++ b/src/karlsenstratum/stratum_server.go
@@ -80,9 +80,9 @@ func ListenAndServe(cfg BridgeConfig) error {
 	}
 
 	shareHandler := newShareHandler(ksApi.karlsend)
-	minDiff := cfg.MinShareDiff
+	minDiff := float64(cfg.MinShareDiff)
 	if minDiff == 0 {
-		minDiff = 4
+		minDiff = 0.1
 	}
 	extranonceSize := cfg.ExtranonceSize
 	if extranonceSize > 3 {


### PR DESCRIPTION
* fix deprecated Node.js warning 4178aa4d5843ca35e7c485dbf32711efe639ea40
https://github.com/actions/setup-go
The V5 edition of the action offers:
**Upgraded Node.js runtime from node16 to node20**

* fix possible varDiff issues and adjust default `min_share_diff` c23f179d3188745a116b56a1d40b8f25f432f8c3
addresses a potential issue where forcing a minimum varDiff caused unexpected behavior or potential race conditions

* reworked default config.yaml:
corrected spelling errors
reduced the default `min_share_diff` value from 64 to 4, since the variable difficulty (var_diff) system will adjust dynamically based on miner. Better to start lower.
explained fallback logic where `minDiff` is set to `0.1` if `cfg.MinShareDiff` is `0`